### PR TITLE
Fix database connection by adding SSL and port config

### DIFF
--- a/backend/config/database.js
+++ b/backend/config/database.js
@@ -8,8 +8,15 @@ const sequelize = new Sequelize(
   {
     host: process.env.DB_HOST,
     dialect: 'mysql',
-    logging: false,
-  }
+    port: process.env.DB_PORT,
+    dialectOptions: {
+      connectTimeout: 60000, // Timeout de 60s pour éviter les échecs de connexion lente
+      ssl: {
+        require: true, // Force l'utilisation de SSL pour la sécurité
+        rejectUnauthorized: false, // Désactive la vérification stricte des certificats
+      },
+    },
+  },
 );
 
 module.exports = sequelize;


### PR DESCRIPTION
Updated Sequelize configuration to include:
- Custom port via DB_PORT environment variable
- dialectOptions with SSL (required, non-strict) and 60s timeout
- Removed dotenv import as it's handled elsewhere This resolves the issue where the app couldn't connect to the remote DB.